### PR TITLE
First cut at an interface for async data loading

### DIFF
--- a/esp-js-ui.d.ts
+++ b/esp-js-ui.d.ts
@@ -251,16 +251,25 @@ export interface ModuleLoadErrorChange {
 
 export type ModuleLoadResult = ModuleLoadChange | ModuleLoadErrorChange;
 
+interface ModuleDescriptor {
+    factory: ModuleConstructor;
+    moduleName: string;
+}
+
 export class ModuleLoader {
     constructor(
-        container: Container,
-        componentRegistryModel: ComponentRegistryModel,
-        stateService:StateService);
+        _container: Container,
+        _componentRegistryModel: ComponentRegistryModel,
+        _stateService:StateService);
 
-    registerModules<ModuleConstructor>(...functionalModules:Array<ModuleConstructor>);
-    loadModules() : Rx.Observable<ModuleLoadResult>;
-    unloadModules();
-    loadLayout(layoutMode:string);
+    public registerModules(...functionalModules: ModuleDescriptor[]): void;
+
+    /**
+     * takes an array of modules class that will be new-ed up, i.e. constructor functions
+     */
+    public loadModules(): Rx.Observable<ModuleLoadResult>;
+    public unloadModules(): void;
+    public loadLayout(layoutMode:string): void;
 }
 
 export class MultiItemRegionEventConst {
@@ -386,3 +395,29 @@ export abstract class ViewBase<TComponent, TModel, TProps extends ViewBaseProps<
     // This view is doing something by way of the generic constraint it's putting on the props, but that's not exactly code reuse.
     // Keeping this here for now, might delete at some point if we don't use it
 }
+
+interface BaseResult {
+    stage: string;
+    name: string;
+}
+
+export interface StartingResult extends BaseResult {
+    stage: 'starting';
+}
+
+export interface CompletedResult extends BaseResult {
+    stage: 'completed';
+}
+
+export interface ErroredResult extends BaseResult {
+    stage: 'error';
+    errorMessage: string;
+}
+
+export type LoadResult = StartingResult | CompletedResult | ErroredResult;
+
+export interface PrerequisiteRegistrar {
+    registerStream(stream: Rx.Observable<Unit>, name: string): void;
+    registerAction(action: () => void, name: string);
+}
+

--- a/esp-js-ui.d.ts
+++ b/esp-js-ui.d.ts
@@ -214,7 +214,7 @@ export interface DefaultStateProvider {
 }
 
 export interface ModuleConstructor {
-    new (container:Container, stateService:StateService) : Module;
+    new (container: Container, stateService: StateService) : Module;
 }
 
 export interface Module extends DisposableBase {
@@ -237,13 +237,28 @@ export abstract class ModuleBase extends DisposableBase implements Module {
     unloadLayout();
 }
 
+export interface ModuleLoadChange {
+    type: 'loadChange';
+    moduleName: string;
+    description: string;
+}
+
+export interface ModuleLoadErrorChange {
+    type: 'loadError';
+    moduleName: string;
+    errorMessage: string;
+}
+
+export type ModuleLoadResult = ModuleLoadChange | ModuleLoadErrorChange;
+
 export class ModuleLoader {
     constructor(
         container: Container,
         componentRegistryModel: ComponentRegistryModel,
         stateService:StateService);
 
-    loadModules<TModule extends ModuleConstructor>(...functionalModules:Array<TModule>);
+    registerModules<ModuleConstructor>(...functionalModules:Array<ModuleConstructor>);
+    loadModules() : Rx.Observable<ModuleLoadResult>;
     unloadModules();
     loadLayout(layoutMode:string);
 }

--- a/esp-js-ui.d.ts
+++ b/esp-js-ui.d.ts
@@ -58,6 +58,11 @@ export class Environment {
     static readonly isRunningOnTablet: boolean;
 }
 
+export class Unit {
+    static readonly default: Unit;
+    private constructor();
+}
+
 export class Guard {
     static isDefined(value: any, message: string): void;
     static isFalse(value: any, message: string): void;

--- a/examples/module-based-app/src/shell/models/shellModel.ts
+++ b/examples/module-based-app/src/shell/models/shellModel.ts
@@ -1,30 +1,65 @@
 import { observeEvent } from 'esp-js';
 import { viewBinding } from 'esp-js-react';
 import ShellView from '../views/shellView';
+import { SplashScreenModel,  SplashScreenState } from './splashScreenModel'; 
 import {
     Logger,
     ModelBase,
     MultiItemRegionModel,
     SingleItemRegionModel,
     ModuleLoader,
-    IdFactory
+    IdFactory,
+    ModuleLoadChange
 } from 'esp-js-ui';
 
 let _log = Logger.create('ShellModel');
 
 @viewBinding(ShellView)
 export default class ShellModel extends ModelBase {
-    private _workspaceRegion:MultiItemRegionModel;
-    private _blotterRegion:SingleItemRegionModel;
+    public splashScreen: SplashScreenModel;
 
     constructor(router,
-                workspaceRegion:MultiItemRegionModel,
-                blotterRegion:SingleItemRegionModel
+                private _moduleLoader: ModuleLoader,
+                private _workspaceRegion:MultiItemRegionModel,
+                private _blotterRegion:SingleItemRegionModel
     ) {
         super(IdFactory.createId('shellModelId'), router);
-        this._workspaceRegion = workspaceRegion;
-        this._blotterRegion = blotterRegion;
+        this.splashScreen = {
+            state: SplashScreenState.Default
+        };
     }
+
+    public init() {
+        this.ensureOnDispatchLoop(() => {
+            this.splashScreen = {
+                state: SplashScreenState.Loading,
+                message: `Loading Modules`
+            };
+
+            this.addDisposable(this._moduleLoader.loadModules().subscribeWithRouter(this.router, this.modelId, (change: ModuleLoadChange) => {
+                _log.debug(`Load Change detected`, change);
+                this.splashScreen = {
+                    state: SplashScreenState.Loading,
+                    message: change.description
+                };
+            },
+            e => {
+                _log.error(`Error in the module load stream.`, e);
+                this.splashScreen = {
+                    state: SplashScreenState.Error,
+                    message: `There has been an error loading the modules.  Please refresh`
+                };
+            },
+            () => {
+                _log.info(`Modules loaded, loading layout`);
+                this._moduleLoader.loadLayout('default-layout-mode');
+                this.splashScreen = {
+                    state: SplashScreenState.Idle
+                };
+            }));
+        });
+    }
+
     observeEvents() {
         super.observeEvents();
         this._blotterRegion.observeEvents();

--- a/examples/module-based-app/src/shell/models/splashScreenModel.ts
+++ b/examples/module-based-app/src/shell/models/splashScreenModel.ts
@@ -1,0 +1,11 @@
+export enum SplashScreenState {
+    Default,
+    Idle,
+    Loading,
+    Error
+}
+
+export interface SplashScreenModel {
+    state: SplashScreenState;
+    message?: string;
+}

--- a/examples/module-based-app/src/shell/shellBootstrapper.tsx
+++ b/examples/module-based-app/src/shell/shellBootstrapper.tsx
@@ -12,7 +12,9 @@ import {
     LiteralResolver,
     SystemContainerConfiguration,
     SystemContainerConst,
-    ModuleLoader
+    ModuleLoader,
+    ModuleDescriptor,
+    ModuleLoadChange
 } from 'esp-js-ui';
 import ShellModel from './models/shellModel';
 import ShellModuleContainerConst from './shellModuleContainerConst';
@@ -55,6 +57,7 @@ class ShellBootstrapper {
             .register(ShellModuleContainerConst.shell_model, ShellModel)
             .inject(
                 SystemContainerConst.router,
+                SystemContainerConst.module_loader,
                 ShellModuleContainerConst.workspace_region,
                 ShellModuleContainerConst.blotter_region
             );
@@ -62,12 +65,18 @@ class ShellBootstrapper {
 
     _loadModules(permissions:Array<string>) {
         this._moduleLoader = this._container.resolve<ModuleLoader>(ShellModuleContainerConst.module_loader);
-        let modulesToLoad = [];
+        let modulesToLoad: ModuleDescriptor[] = [];
         if(permissions.indexOf(TradingModule.requiredPermission) >= 0) {
-            modulesToLoad.push(TradingModule);
+            let descriptor: ModuleDescriptor = {
+                factory:  TradingModule,
+                moduleName: 'Trading Module'
+            };
+            modulesToLoad.push(descriptor);
         }
-        this._moduleLoader.loadModules(...modulesToLoad);
-        this._moduleLoader.loadLayout('default-layout-mode');
+        this._moduleLoader.registerModules(...modulesToLoad);
+
+        let shellModel = this._container.resolve<ShellModel>(ShellModuleContainerConst.shell_model);
+        shellModel.init();
     }
 
     _displayShell() {

--- a/examples/module-based-app/src/shell/views/shellView.tsx
+++ b/examples/module-based-app/src/shell/views/shellView.tsx
@@ -3,14 +3,15 @@ import {Router} from 'esp-js';
 import {SmartComponent} from 'esp-js-react';
 import {MultiItemRegionView, SingleItemRegionView} from 'esp-js-ui';
 import ShellModel from '../models/shellModel';
+import { SplashScreenState } from '../models/splashScreenModel';
 
 export default class ShellView extends React.Component<{model:ShellModel, router:Router}, any> {
     render() {
         let model : ShellModel = this.props.model;
-        return (
-            <div>
-                <h1>Shell View</h1>
-                <div className='main-content'>
+        let mainContent;
+
+        if(model.splashScreen.state === SplashScreenState.Idle) {
+            mainContent = (<div className='main-content'>
                     <div className='workspace'>
                         <SmartComponent
                             view={MultiItemRegionView}
@@ -24,7 +25,21 @@ export default class ShellView extends React.Component<{model:ShellModel, router
                             modelId={model.blotterRegion.modelId}
                         />
                     </div>
+                </div>);
+        } else if(model.splashScreen.state === SplashScreenState.Default) {
+            mainContent = null;
+        } else {
+            mainContent = (
+                <div>
+                    {model.splashScreen.message}
                 </div>
+            );
+        }
+
+        return (
+            <div>
+                <h1>Shell View</h1>
+                {mainContent}
             </div>
         );
     }

--- a/examples/module-based-app/src/trading-module/tradingModule.ts
+++ b/examples/module-based-app/src/trading-module/tradingModule.ts
@@ -1,6 +1,6 @@
 import * as uuid from 'uuid';
 import { Container, MicroDiConsts } from 'microdi-js';
-import { ModuleBase, StateService, ComponentFactoryBase, SystemContainerConst } from 'esp-js-ui';
+import { ModuleBase, StateService, ComponentFactoryBase, SystemContainerConst, PrerequisiteRegistrar } from 'esp-js-ui';
 import TradingModuleDefautStateProvider from './tradingModuleDefaultStateProvider';
 import TradingModuleContainerConst from './tradingModuleContainerConst';
 import CashTileComponentFactory from './cash-tile/cashTileComponentFactory';
@@ -52,5 +52,9 @@ export default class TradingModule extends ModuleBase {
 
     getComponentsFactories():Array<ComponentFactoryBase> {
         return this.container.resolveGroup(this._componentFactoryGroupId);
+    }
+
+    registerPrerequisites(registrar: PrerequisiteRegistrar): void {
+        registrar.registerStream(Rx.Observable.timer(2000).take(1), 'Loading Referential Data');
     }
 }

--- a/examples/module-based-app/yarn.lock
+++ b/examples/module-based-app/yarn.lock
@@ -813,18 +813,18 @@ esp-js-react@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/esp-js-react/-/esp-js-react-0.1.6.tgz#5ad5926cd08b71b1feebfbf27967681bd237b131"
 
-esp-js-ui@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/esp-js-ui/-/esp-js-ui-0.1.1.tgz#9f9b15d665848d2d216ff89d779b3a80dd906916"
+esp-js-ui@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/esp-js-ui/-/esp-js-ui-0.2.0.tgz#abd4536b10cd0ccab1d0e09f4f96ae44a4bf3df4"
   dependencies:
     classnames "2.2.5"
     esp-js "^1.3.0"
     esp-js-react "0.1.6"
     microdi-js "^1.1.0"
-    node-uuid "^1.4.8"
     query-string "^4.3.2"
     react "15.3.2"
     rx "4.1.0"
+    uuid "3.0.1"
 
 esp-js@1.3.0, esp-js@^1.3.0:
   version "1.3.0"
@@ -1674,10 +1674,6 @@ node-pre-gyp@^0.6.29:
     semver "^5.3.0"
     tar "^2.2.1"
     tar-pack "^3.4.0"
-
-node-uuid@^1.4.8:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
 
 nopt@^4.0.1:
   version "4.0.1"

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -8,4 +8,5 @@ export { default as Environment } from './environment';
 export * from './logger';
 export { default as Logger } from './logger';
 export * from './schedulerService';
+export { default as Unit } from './unit';
 export { default as Utils } from './utils';

--- a/src/core/observableExt/doOnSubscribe.ts
+++ b/src/core/observableExt/doOnSubscribe.ts
@@ -1,0 +1,9 @@
+import * as Rx from 'rx';
+
+Rx.Observable.prototype.doOnSubscribe = function<T>(action: () => void) : Rx.Observable<T> {
+    let source = this;
+    return Rx.Observable.defer<T>(() => {
+        action();
+        return source;
+    });
+};

--- a/src/core/observableExt/index.ts
+++ b/src/core/observableExt/index.ts
@@ -1,4 +1,5 @@
-// retryWithPolicy doesn't have exports but it does add ext methods to rx
+import './lazyConnect';
 import './retryWithPolicy';
 import './subscribeWithRouter';
+import './takeUntilInclusive';
 export { default as RetryPolicy } from './retryPolicy';

--- a/src/core/observableExt/index.ts
+++ b/src/core/observableExt/index.ts
@@ -1,3 +1,4 @@
+import './doOnSubscribe';
 import './lazyConnect';
 import './retryWithPolicy';
 import './subscribeWithRouter';

--- a/src/core/observableExt/lazyConnect.ts
+++ b/src/core/observableExt/lazyConnect.ts
@@ -1,0 +1,16 @@
+import * as Rx from 'rx';
+
+Rx.Observable.prototype.lazyConnect = function<T>(disposable: Rx.Disposable) : Rx.Observable<T> {
+    let source = this;
+    let isConnected = false;
+    return Rx.Observable.create<T>(obs => {
+        let subscription = source.subscribe(obs);
+
+        // Ensure we subscribe first before we connect to avoid any races
+        if(!isConnected) {
+            disposable = source.connect();
+            isConnected = true;
+        }
+        return subscription;
+    });
+};

--- a/src/core/observableExt/takeUntilInclusive.ts
+++ b/src/core/observableExt/takeUntilInclusive.ts
@@ -1,0 +1,15 @@
+import * as Rx from 'rx';
+
+Rx.Observable.prototype.takeUntilInclusive = function<T>(predicate: (item: T) => boolean) : Rx.Observable<T> {
+    let source = this;
+    return Rx.Observable.create<T>(obs => {
+        return source.subscribe(item => {
+            obs.onNext(item);
+            if (predicate(item)) {
+                obs.onCompleted();
+            }
+        },
+        e => obs.onError(e),
+        () =>  obs.onCompleted());
+    });
+};

--- a/src/core/unit.ts
+++ b/src/core/unit.ts
@@ -1,0 +1,4 @@
+export default class Unit {
+    public static readonly default: Unit = new Unit();
+    private constructor() {}
+};

--- a/src/ui/dependencyInjection/systemContainerConfiguration.ts
+++ b/src/ui/dependencyInjection/systemContainerConfiguration.ts
@@ -25,7 +25,7 @@ export default class SystemContainerConfiguration {
         rootContainer.register(SystemContainerConst.region_manager, RegionManager);
         rootContainer.register(SystemContainerConst.scheduler_service, SchedulerService);
 
-        // module loader
+        // functionalModule loader
         rootContainer.register(SystemContainerConst.module_loader, ModuleLoader)
             .inject(
                 MicroDiConsts.owningContainer,

--- a/src/ui/dependencyInjection/systemContainerConfiguration.ts
+++ b/src/ui/dependencyInjection/systemContainerConfiguration.ts
@@ -25,7 +25,7 @@ export default class SystemContainerConfiguration {
         rootContainer.register(SystemContainerConst.region_manager, RegionManager);
         rootContainer.register(SystemContainerConst.scheduler_service, SchedulerService);
 
-        // functionalModule loader
+        // module loader
         rootContainer.register(SystemContainerConst.module_loader, ModuleLoader)
             .inject(
                 MicroDiConsts.owningContainer,

--- a/src/ui/modules/componentFactoryState.ts
+++ b/src/ui/modules/componentFactoryState.ts
@@ -1,0 +1,5 @@
+interface ComponentFactoryState {
+    componentFactoryKey:string;
+    componentsState: Array<any>;
+}
+export default ComponentFactoryState;

--- a/src/ui/modules/defaultStateProvider.ts
+++ b/src/ui/modules/defaultStateProvider.ts
@@ -1,0 +1,7 @@
+import ComponentFactoryState from './componentFactoryState';
+
+interface DefaultStateProvider {
+    getComponentFactoriesState(layoutMode:string):Array<ComponentFactoryState>;
+}
+
+export default DefaultStateProvider;

--- a/src/ui/modules/index.ts
+++ b/src/ui/modules/index.ts
@@ -1,11 +1,8 @@
 export * from './prerequisites';
+export { default as ComponentFactoryState } from './componentFactoryState';
+export { default as DefaultStateProvider } from './defaultStateProvider';
 export { default as Module } from './module';
-export {
-    default as ModuleBase,
-    ComponentFactoryState,
-    DefaultStateProvider,
-} from './moduleBase';
-
+export { default as ModuleBase } from './moduleBase';
 export { default as ModuleConstructor } from './moduleConstructor';
 export { default as ModuleDescriptor } from './moduleDescriptor';
 export * from './moduleLoadResult';

--- a/src/ui/modules/index.ts
+++ b/src/ui/modules/index.ts
@@ -1,3 +1,4 @@
+export * from './prerequisites';
 export {
     default as ModuleBase,
     Module,

--- a/src/ui/modules/index.ts
+++ b/src/ui/modules/index.ts
@@ -1,9 +1,13 @@
 export * from './prerequisites';
+export { default as Module } from './module';
 export {
     default as ModuleBase,
-    Module,
     ComponentFactoryState,
     DefaultStateProvider,
-    ModuleConstructor
 } from './moduleBase';
+
+export { default as ModuleConstructor } from './moduleConstructor';
+export { default as ModuleDescriptor } from './moduleDescriptor';
+export * from './moduleLoadResult';
 export { default as ModuleLoader } from './moduleLoader';
+export { default as SingleModuleLoader } from './singleModuleLoader';

--- a/src/ui/modules/module.ts
+++ b/src/ui/modules/module.ts
@@ -1,0 +1,22 @@
+import {DisposableBase} from 'esp-js';
+import ComponentRegistryModel from '../components/componentRegistryModel';
+import PrerequisiteRegistrar from './prerequisites/prerequisiteRegistrar';
+
+interface Module extends DisposableBase {
+
+    initialise(): void;
+
+    configureContainer(): void;
+
+    registerComponents(componentRegistryModel:ComponentRegistryModel);
+
+    getComponentsFactories();
+
+    loadLayout(layoutMode:string);
+
+    unloadLayout(): void;
+
+    registerPrerequisites(registrar: PrerequisiteRegistrar): void;
+}
+
+export default Module;

--- a/src/ui/modules/moduleBase.ts
+++ b/src/ui/modules/moduleBase.ts
@@ -5,6 +5,7 @@ import ComponentRegistryModel from '../components/componentRegistryModel';
 import ComponentFactoryBase from '../components/componentFactoryBase';
 import Logger from '../../core/logger';
 import Guard from '../../core/guard';
+import PrerequisiteRegistrar from './prerequisites/prerequisiteRegistrar';
 
 export interface ComponentFactoryState {
     componentFactoryKey:string;
@@ -33,76 +34,8 @@ export interface Module extends DisposableBase {
 
     unloadLayout(): void;
 
-    registerAsyncDataRequirements(registrar: AsyncDataRegistrar): void;
+    registerPrerequisites(registrar: PrerequisiteRegistrar): void;
 }
-
-export class AsyncDataRegistrar {
-    private _stream: Rx.Observable<LoadResult> = Rx.Observable.empty<LoadResult>();
-    private _log: Logger = Logger.create('AsyncDataRegistrar');
-
-    public registerStream(stream: Rx.Observable<any>, name: string): void {
-        let builtStream = Rx.Observable.create<LoadResult>(obs => {
-            obs.onNext({
-               stage: 'starting',
-               name
-            });
-
-            let handleError = (e: Error) => {
-                let message = `Error in async load for ${name}`;
-                this._log.error(message, e);
-
-                obs.onNext({
-                    stage: 'error',
-                    name,
-                    errorMessage: message
-                });
-            };
-
-            return stream
-                .take(1)
-                .ignoreElements()
-                .subscribe(
-                    _ => {},
-                    e =>  handleError(e),
-                    () => {
-                        obs.onNext({
-                            stage: 'completed',
-                            name
-                        });
-                    }
-                );
-        });
-
-        this._stream = this._stream.concat(builtStream);
-    }
-
-    public registerAction(action: () => void, name: string) {
-        let stream = Rx.Observable.create<any>(obs => action());
-        this.registerStream(stream, name);
-    }
-
-    public load(): Rx.Observable<LoadResult> {
-        return this._stream;
-    }
-}
-
-interface StartingLoadResult {
-    stage: 'starting';
-    name: string;
-}
-
-interface CompletedLoadResult {
-    stage: 'completed';
-    name: string;
-}
-
-interface ErroredLoadResult {
-    stage: 'error';
-    name: string;
-    errorMessage: string;
-}
-
-type LoadResult = StartingLoadResult | CompletedLoadResult | ErroredLoadResult;
 
 export abstract class ModuleBase extends DisposableBase implements Module {
     protected container:Container;
@@ -128,6 +61,8 @@ export abstract class ModuleBase extends DisposableBase implements Module {
     }
 
     abstract configureContainer();
+
+    abstract registerPrerequisites(registrar: PrerequisiteRegistrar): void;
 
     registerComponents(componentRegistryModel:ComponentRegistryModel) {
         this._log.debug('Registering components');

--- a/src/ui/modules/moduleBase.ts
+++ b/src/ui/modules/moduleBase.ts
@@ -6,6 +6,7 @@ import ComponentFactoryBase from '../components/componentFactoryBase';
 import Logger from '../../core/logger';
 import Guard from '../../core/guard';
 import PrerequisiteRegistrar from './prerequisites/prerequisiteRegistrar';
+import Module from './module';
 
 export interface ComponentFactoryState {
     componentFactoryKey:string;
@@ -14,27 +15,6 @@ export interface ComponentFactoryState {
 
 export interface DefaultStateProvider {
     getComponentFactoriesState(layoutMode:string):Array<ComponentFactoryState>;
-}
-
-export interface ModuleConstructor {
-    new (container:Container, stateService:StateService) : Module;
-}
-
-export interface Module extends DisposableBase {
-
-    initialise(): void;
-
-    configureContainer(): void;
-
-    registerComponents(componentRegistryModel:ComponentRegistryModel);
-
-    getComponentsFactories();
-
-    loadLayout(layoutMode:string);
-
-    unloadLayout(): void;
-
-    registerPrerequisites(registrar: PrerequisiteRegistrar): void;
 }
 
 export abstract class ModuleBase extends DisposableBase implements Module {
@@ -55,8 +35,8 @@ export abstract class ModuleBase extends DisposableBase implements Module {
         this._stateService = stateService;
         this._defaultStateProvider = defaultStateProvider;
         this._log = Logger.create('ModuleBase');
-        // seems to make sense for the module to own it's container,
-        // disposing the module will dispose it's container and thus all it's child components.
+        // seems to make sense for the functionalModule to own it's container,
+        // disposing the functionalModule will dispose it's container and thus all it's child components.
         this.addDisposable(container);
     }
 

--- a/src/ui/modules/moduleBase.ts
+++ b/src/ui/modules/moduleBase.ts
@@ -7,15 +7,8 @@ import Logger from '../../core/logger';
 import Guard from '../../core/guard';
 import PrerequisiteRegistrar from './prerequisites/prerequisiteRegistrar';
 import Module from './module';
-
-export interface ComponentFactoryState {
-    componentFactoryKey:string;
-    componentsState: Array<any>;
-}
-
-export interface DefaultStateProvider {
-    getComponentFactoriesState(layoutMode:string):Array<ComponentFactoryState>;
-}
+import DefaultStateProvider from './defaultStateProvider';
+import ComponentFactoryState from './componentFactoryState';
 
 export abstract class ModuleBase extends DisposableBase implements Module {
     protected container:Container;

--- a/src/ui/modules/moduleBase.ts
+++ b/src/ui/modules/moduleBase.ts
@@ -28,8 +28,8 @@ export abstract class ModuleBase extends DisposableBase implements Module {
         this._stateService = stateService;
         this._defaultStateProvider = defaultStateProvider;
         this._log = Logger.create('ModuleBase');
-        // seems to make sense for the functionalModule to own it's container,
-        // disposing the functionalModule will dispose it's container and thus all it's child components.
+        // seems to make sense for the module to own it's container,
+        // disposing the module will dispose it's container and thus all it's child components.
         this.addDisposable(container);
     }
 

--- a/src/ui/modules/moduleConstructor.ts
+++ b/src/ui/modules/moduleConstructor.ts
@@ -1,0 +1,9 @@
+import StateService from '../state/stateService';
+import {Container} from 'microdi-js';
+import Module from './module';
+
+interface ModuleConstructor {
+    new (container:Container, stateService:StateService) : Module;
+}
+
+export default ModuleConstructor;

--- a/src/ui/modules/moduleDescriptor.ts
+++ b/src/ui/modules/moduleDescriptor.ts
@@ -1,0 +1,7 @@
+import ModuleConstructor from './moduleConstructor';
+interface ModuleDescriptor {
+    factory: ModuleConstructor;
+    moduleName: string;
+}
+
+export default ModuleDescriptor;

--- a/src/ui/modules/moduleLoadResult.ts
+++ b/src/ui/modules/moduleLoadResult.ts
@@ -1,0 +1,13 @@
+export interface ModuleLoadChange {
+    type: 'loadChange';
+    moduleName: string;
+    description: string;
+}
+
+export interface ModuleLoadErrorChange {
+    type: 'loadError';
+    moduleName: string;
+    errorMessage: string;
+}
+
+export type ModuleLoadResult = ModuleLoadChange | ModuleLoadErrorChange;

--- a/src/ui/modules/moduleLoader.ts
+++ b/src/ui/modules/moduleLoader.ts
@@ -11,6 +11,7 @@ let _log = Logger.create('ModuleLoader');
 
 export default class ModuleLoader {
     private _modules: Array<{moduleLoader: SingleModuleLoader, name: string}> = [];
+    private _moduleDescriptors: ModuleDescriptor[];
 
     constructor(
         private _container: Container,
@@ -18,14 +19,18 @@ export default class ModuleLoader {
         private _stateService:StateService) {
     }
 
+    public registerModules(...functionalModules: ModuleDescriptor[]): void {
+        this._moduleDescriptors = functionalModules;
+    }
+
     /**
      * takes an array of modules class that will be new-ed up, i.e. constructor functions
      */
-    public loadModules(...functionalModules: ModuleDescriptor[]): Rx.Observable<ModuleLoadResult> {
+    public loadModules(): Rx.Observable<ModuleLoadResult> {
         return Rx.Observable.create<ModuleLoadResult>(obs => {
             _log.debug('loading modules');
 
-            let moduleLoaders = functionalModules.map(descriptor => {
+            let moduleLoaders = this._moduleDescriptors.map(descriptor => {
                 let singleModuleLoader = new SingleModuleLoader(
                     this._container,
                     this._componentRegistryModel,

--- a/src/ui/modules/moduleLoader.ts
+++ b/src/ui/modules/moduleLoader.ts
@@ -1,73 +1,62 @@
+import * as Rx from 'rx';
 import { Container } from 'microdi-js';
 import ComponentRegistryModel from '../components/componentRegistryModel';
 import StateService from '../state/stateService';
-import {ModuleConstructor, Module} from './moduleBase';
 import Logger from '../../core/logger';
+import ModuleDescriptor from './moduleDescriptor';
+import {ModuleLoadResult} from './moduleLoadResult';
+import SingleModuleLoader from './singleModuleLoader';
 
 let _log = Logger.create('ModuleLoader');
 
 export default class ModuleLoader {
-    private _container :Container;
-    private _componentRegistryModel :ComponentRegistryModel;
-    private _modules :Array<Module>;
-    private _stateService :StateService;
+    private _modules: Array<{moduleLoader: SingleModuleLoader, name: string}> = [];
 
     constructor(
-        container: Container,
-        componentRegistryModel: ComponentRegistryModel,
-        stateService:StateService) {
-        this._container = container;
-        this._componentRegistryModel = componentRegistryModel;
-        this._modules = [];
-        this._stateService = stateService;
+        private _container: Container,
+        private _componentRegistryModel: ComponentRegistryModel,
+        private _stateService:StateService) {
     }
 
     /**
      * takes an array of modules class that will be new-ed up, i.e. constructor functions
      */
-    loadModules<TModule extends ModuleConstructor>(...functionalModules:Array<TModule>) {
-        _log.debug('starting modules');
-        for (let i = 0; i < functionalModules.length; i++) {
-            let FunctionalModule = functionalModules[i];
-            let functionalModule = new FunctionalModule(
-                this._container.createChildContainer(),
-                this._stateService
-            );
-            this._modules.push(functionalModule);
-        }
-        this._configureModulesContainer();
-        this._registerModulesComponents();
-        this._initialiseModules();
+    public loadModules(...functionalModules: ModuleDescriptor[]): Rx.Observable<ModuleLoadResult> {
+        return Rx.Observable.create<ModuleLoadResult>(obs => {
+            _log.debug('loading modules');
+
+            let moduleLoaders = functionalModules.map(descriptor => {
+                let singleModuleLoader = new SingleModuleLoader(
+                    this._container,
+                    this._componentRegistryModel,
+                    this._stateService,
+                    descriptor);
+                
+                this._modules.push({
+                    moduleLoader: singleModuleLoader, name: descriptor.moduleName
+                });
+                
+                return singleModuleLoader;
+            });
+            
+            return Rx.Observable.concat(moduleLoaders.map(m => m.load())).subscribe(obs);
+        });
     }
-    unloadModules() {
-        // note re reverse the modules here inorder to dispose the service module last,
-        // all other modules container are child containers of the service container (see notes above)
+
+    public unloadModules(): void {
+        // all modules' container are child containers of the service container (see notes above)
         this._modules
-            .reverse()
-            .forEach((module:Module) => {
-                module.unloadLayout();
-                module.dispose();
+            .forEach(moduleItem => {
+                _log.debug(`Unloading module ${moduleItem.name}`);
+                moduleItem.moduleLoader.functionalModule.unloadLayout();
+                moduleItem.moduleLoader.functionalModule.dispose();
             });
         this._modules.length = 0;
     }
-    loadLayout(layoutMode:string) {
-        this._modules.forEach((module:Module) => {
-            module.loadLayout(layoutMode);
+
+    public loadLayout(layoutMode:string): void {
+        this._modules.forEach(moduleItem => {
+            _log.debug(`Loading layout for ${moduleItem.name}`);
+            moduleItem.moduleLoader.functionalModule.loadLayout(layoutMode);
         });
-    }
-    _configureModulesContainer() {
-        this._modules.forEach((module:Module) => {
-            module.configureContainer();
-        });
-    }
-    _registerModulesComponents() {
-        this._modules.forEach((module:Module) => {
-            module.registerComponents(this._componentRegistryModel);
-        });
-    }
-    _initialiseModules() {
-        this._modules.forEach((module:Module) => {
-            module.initialise();
-        });
-    }
 }

--- a/src/ui/modules/moduleLoader.ts
+++ b/src/ui/modules/moduleLoader.ts
@@ -64,4 +64,5 @@ export default class ModuleLoader {
             _log.debug(`Loading layout for ${moduleItem.name}`);
             moduleItem.moduleLoader.functionalModule.loadLayout(layoutMode);
         });
+    }
 }

--- a/src/ui/modules/prerequisites/defaultPrerequisiteRegistrar.ts
+++ b/src/ui/modules/prerequisites/defaultPrerequisiteRegistrar.ts
@@ -1,0 +1,82 @@
+import * as Rx from 'rx';
+import {DisposableBase} from 'esp-js';
+import PrerequisiteRegistrar from './prerequisiteRegistrar';
+import {LoadResult} from './loadResult';
+import Logger from '../../../core/logger';
+import Unit from '../../../core/unit';
+
+export default class DefaultPrerequisiteRegistrar extends DisposableBase implements PrerequisiteRegistrar  {
+    private _stream: Rx.Observable<LoadResult> = Rx.Observable.empty<LoadResult>();
+    private _publishedStream: Rx.Observable<LoadResult>;
+    private _log: Logger = Logger.create('PrerequisiteRegistrar');
+
+    constructor() {
+        super();
+
+        let loadDisposable = new Rx.SingleAssignmentDisposable();
+        this.addDisposable(loadDisposable);
+
+        this._stream = Rx.Observable.empty<LoadResult>();
+        this._publishedStream = Rx.Observable.defer<LoadResult>(() => {
+            // We close over _stream so that we allow the class to modify
+            // it (see registerStream function)
+            return this._stream;
+        })
+        // When we load, stop on the first error result we get
+        // But yield it back to the consumer so they know it stopped
+            .takeUntilInclusive((result: LoadResult) =>  result.stage === 'error')
+            .multicast(new Rx.AsyncSubject<LoadResult>())
+            .lazyConnect<LoadResult>(loadDisposable);
+    }
+
+    public registerAction(action: () => void, name: string) {
+        let stream = Rx.Observable.create<any>(obs => action());
+        this.registerStream(stream, name);
+    }
+
+    public load(): Rx.Observable<LoadResult> {
+        // We have to assume that if someone calls load,
+        // all streams /actions have been registered.
+        return this._publishedStream;
+    }
+
+    public registerStream(stream: Rx.Observable<Unit>, name: string): void {
+        let builtStream = this._buildStream(stream, name);
+        this._stream = this._stream.concat(builtStream);
+    }
+
+    private _buildStream(stream: Rx.Observable<Unit>, name: string) : Rx.Observable<LoadResult> {
+        return Rx.Observable.create<LoadResult>(obs => {
+            obs.onNext({
+                stage: 'starting',
+                name
+            });
+
+            let handleError = (e: Error) => {
+                let message = `Error in async load for ${name}`;
+                this._log.error(message, e);
+
+                obs.onNext({
+                    stage: 'error',
+                    name,
+                    errorMessage: message
+                });
+            };
+
+            return stream
+                .take(1)
+                .ignoreElements()
+                .subscribe(
+                    _ => {
+                    },
+                    e => handleError(e),
+                    () => {
+                        obs.onNext({
+                            stage: 'completed',
+                            name
+                        });
+                    }
+                );
+        });
+    }
+}

--- a/src/ui/modules/prerequisites/index.ts
+++ b/src/ui/modules/prerequisites/index.ts
@@ -1,0 +1,3 @@
+export { default as DefaultPrerequisiteRegistrar} from './defaultPrerequisiteRegistrar';
+export * from './loadResult';
+export { default as PrerequisiteRegistrar} from './prerequisiteRegistrar';

--- a/src/ui/modules/prerequisites/loadResult.ts
+++ b/src/ui/modules/prerequisites/loadResult.ts
@@ -1,17 +1,19 @@
-export interface StartingLoadResult {
+interface BaseResult {
+    stage: string;
+    name: string;
+}
+
+export interface StartingResult extends BaseResult {
     stage: 'starting';
-    name: string;
 }
 
-export interface CompletedLoadResult {
+export interface CompletedResult extends BaseResult {
     stage: 'completed';
-    name: string;
 }
 
-export interface ErroredLoadResult {
+export interface ErroredResult extends BaseResult {
     stage: 'error';
-    name: string;
     errorMessage: string;
 }
 
-export type LoadResult = StartingLoadResult | CompletedLoadResult | ErroredLoadResult;
+export type LoadResult = StartingResult | CompletedResult | ErroredResult;

--- a/src/ui/modules/prerequisites/loadResult.ts
+++ b/src/ui/modules/prerequisites/loadResult.ts
@@ -1,0 +1,17 @@
+export interface StartingLoadResult {
+    stage: 'starting';
+    name: string;
+}
+
+export interface CompletedLoadResult {
+    stage: 'completed';
+    name: string;
+}
+
+export interface ErroredLoadResult {
+    stage: 'error';
+    name: string;
+    errorMessage: string;
+}
+
+export type LoadResult = StartingLoadResult | CompletedLoadResult | ErroredLoadResult;

--- a/src/ui/modules/prerequisites/prerequisiteRegistrar.ts
+++ b/src/ui/modules/prerequisites/prerequisiteRegistrar.ts
@@ -1,0 +1,10 @@
+import * as Rx from 'rx';
+import Unit from '../../../core/unit';
+
+interface PrerequisiteRegistrar {
+    registerStream(stream: Rx.Observable<Unit>, name: string): void;
+    registerAction(action: () => void, name: string);
+}
+
+export default PrerequisiteRegistrar;
+

--- a/src/ui/modules/singleModuleLoader.ts
+++ b/src/ui/modules/singleModuleLoader.ts
@@ -1,0 +1,124 @@
+import DefaultPrerequisiteRegistrar from './prerequisites/defaultPrerequisiteRegistrar';
+import Logger from '../../core/logger';
+import {Container} from 'microdi-js';
+import {ModuleLoadResult} from './moduleLoadResult';
+import ComponentRegistryModel from '../components/componentRegistryModel';
+import ModuleDescriptor from './moduleDescriptor';
+import StateService from '../state/stateService';
+import {LoadResult} from './prerequisites/loadResult';
+import Module from './module';
+
+export default class SingleModuleLoader {
+    private _preReqsLoader: DefaultPrerequisiteRegistrar;
+    private _log: Logger;
+    
+    public functionalModule: Module;
+
+    constructor(private _container: Container,
+                private _componentRegistryModel: ComponentRegistryModel,
+                private _stateService:StateService,
+                private _descriptor: ModuleDescriptor
+    ) {
+
+        this._log = Logger.create(`SingleModuleLoader-${this._descriptor.moduleName}`);
+        this._preReqsLoader = new DefaultPrerequisiteRegistrar();
+    }
+
+    public load(): Rx.Observable<ModuleLoadResult> {
+        return Rx.Observable.create<ModuleLoadResult>(obs => {
+            let moduleName = this._descriptor.moduleName;
+            obs.onNext({
+                type: 'loadChange',
+                moduleName: moduleName,
+                description: `Starting module ${moduleName}`
+            });
+
+            try {
+                this._log.debug(`Creating module ${moduleName}`);
+
+                let FunctionalModule = this._descriptor.factory;
+                this.functionalModule = new FunctionalModule(
+                    this._container.createChildContainer(),
+                    this._stateService
+                );
+
+                this._log.debug(`Configuring Container for ${moduleName}`);
+                this.functionalModule.configureContainer();
+
+                this._log.debug(`Registering Components for ${moduleName}`);
+                this.functionalModule.registerComponents(this._componentRegistryModel);
+
+                this._log.debug(`Registering prereqs for ${moduleName}`);
+                this.functionalModule.registerPrerequisites(this._preReqsLoader);
+            } catch (e) {
+                this._log.error(`Failed to create module ${moduleName}`, e);
+                obs.onNext({
+                    type: 'loadError',
+                    moduleName,
+                    errorMessage: `Failed to load module ${moduleName}`
+                });
+                obs.onCompleted();
+                return () => {};
+            }
+
+            let initStream = this._buildInitStream(this.functionalModule);
+
+            // Don`t forget about initialising the functionalModule
+            // and then yielding a complete
+            return this._preReqsLoader
+                .load()
+                .map((result: LoadResult) => this._mapLoadResult(result))
+                .concat(initStream)
+                .subscribe(obs);
+        });
+    }
+
+    private _buildInitStream(functionalModule: Module): Rx.Observable<ModuleLoadResult> {
+        return Rx.Observable.create<ModuleLoadResult>(obs => {
+            try {
+                functionalModule.initialise();
+                obs.onNext({
+                    type: 'loadChange',
+                    moduleName: this._descriptor.moduleName,
+                    description: `Initialised Module ${this._descriptor.moduleName}`
+                });
+            } catch (e) {
+                this._log.error(`Failed to initialise module ${this._descriptor.moduleName}`, e);
+                obs.onNext({
+                    type: 'loadError',
+                    moduleName: this._descriptor.moduleName,
+                    errorMessage: `Failed to load module $this._descriptor.moduleName}`
+                });
+                return () => {};
+            }
+        })
+            .take(1);
+    }
+
+    private _mapLoadResult(result: LoadResult) : ModuleLoadResult {
+        switch(result.stage) {
+            case 'starting':
+                return {
+                    type: 'loadChange',
+                    moduleName: this._descriptor.moduleName,
+                    description: `Started  Loading ${result.name}`
+                };
+            case 'completed':
+                return {
+                    type: 'loadChange',
+                    moduleName: this._descriptor.moduleName,
+                    description: `Finished loading ${result.name}`
+                };
+            case 'error':
+                return {
+                    type: 'loadError',
+                    moduleName: this._descriptor.moduleName,
+                    errorMessage: `Error loading ${result.name} ${result.errorMessage}`
+                };
+            default:
+                let errorMessage = `Unknown stage from the pre-req loader for ${this._descriptor.moduleName}.`;
+                this._log.error(errorMessage, result);
+                throw new Error(errorMessage);
+        }
+    }
+}

--- a/src/ui/modules/singleModuleLoader.ts
+++ b/src/ui/modules/singleModuleLoader.ts
@@ -101,13 +101,13 @@ export default class SingleModuleLoader {
                 return {
                     type: 'loadChange',
                     moduleName: this._descriptor.moduleName,
-                    description: `Started  Loading ${result.name}`
+                    description: result.name
                 };
             case 'completed':
                 return {
                     type: 'loadChange',
                     moduleName: this._descriptor.moduleName,
-                    description: `Finished loading ${result.name}`
+                    description: `Finished ${result.name}`
                 };
             case 'error':
                 return {

--- a/tests/core/decimal.test.ts
+++ b/tests/core/decimal.test.ts
@@ -1,10 +1,5 @@
 import Decimal from '../../src/core/decimal';
 describe('Decimal', () => {
-
-    beforeEach(() => {
-
-    });
-
     describe('parse', () => {
         it('returns null when passed invalid value', () => {
             expect(Decimal.parse({})).toEqual(null);

--- a/tests/ui/modules/preprequisites/prerequisiteRegistrar.test.ts
+++ b/tests/ui/modules/preprequisites/prerequisiteRegistrar.test.ts
@@ -212,7 +212,19 @@ describe('Default Prerequisite Registrar Tests', () => {
         });
 
         it('Should handle a case where a stream does not yield and just completes', () => {
+            let stream = new Rx.Subject();
 
+            let counter = 0;
+            registrar.registerStream(stream, 'stream1');
+
+            registrar.load()
+                .subscribe(() => {}, () => {}, () => {
+                    counter++;
+                });
+
+            expect(counter).toEqual(0);
+            stream.onCompleted();
+            expect(counter).toEqual(1);
         });
     });
 });

--- a/tests/ui/modules/preprequisites/prerequisiteRegistrar.test.ts
+++ b/tests/ui/modules/preprequisites/prerequisiteRegistrar.test.ts
@@ -1,0 +1,20 @@
+import DefaultPrerequisiteRegistrar from '../../../../src/ui/modules/prerequisites/defaultPrerequisiteRegistrar';
+describe('Default Prerequisite Registrar Tests', () => {
+    let registrar = new DefaultPrerequisiteRegistrar();
+    
+    beforeEach(() => {
+        
+    });
+    
+    describe('Error Tests', () => {
+        
+    });
+    
+    describe('Actions are handled tests', () => {
+        
+    });
+    
+    describe('Streams tests', () => {
+        
+    })
+});

--- a/tests/ui/modules/preprequisites/prerequisiteRegistrar.test.ts
+++ b/tests/ui/modules/preprequisites/prerequisiteRegistrar.test.ts
@@ -1,20 +1,218 @@
+import * as Rx from 'rx';
+import '../../../../src/core/observableExt';
 import DefaultPrerequisiteRegistrar from '../../../../src/ui/modules/prerequisites/defaultPrerequisiteRegistrar';
+import Unit from '../../../../src/core/unit';
+import {LoadResult} from '../../../../src/ui/modules/prerequisites/loadResult';
+
 describe('Default Prerequisite Registrar Tests', () => {
-    let registrar = new DefaultPrerequisiteRegistrar();
+    let registrar: DefaultPrerequisiteRegistrar;
     
     beforeEach(() => {
-        
+        registrar = new DefaultPrerequisiteRegistrar();
     });
     
     describe('Error Tests', () => {
-        
+        it('Should yield back an error result and not onError', () => {
+           let stream = new Rx.Subject();
+           registrar.registerStream(stream, 'Cohagen');
+
+           let actualResult;
+           let onNextCount = 0;
+           let errorCount = 0;
+           let onCompletedCount = 0;
+
+           registrar.load()
+               .subscribe(result => {
+                   actualResult = result;
+                   onNextCount++;
+               },
+               e => {
+                   errorCount++;
+               },
+               () => {
+                    onCompletedCount++;
+               });
+
+           stream.onError(new Error('Spanner in the works'));
+
+           expect(errorCount).toEqual(0);
+           expect(onCompletedCount).toEqual(1);
+           expect(onNextCount).toEqual(2);
+           expect(actualResult.stage).toEqual('error');
+        });
+
+        it('Should not run subsequent streams after an error', () => {
+            let stream = new Rx.Subject();
+            registrar.registerStream(stream, 'Cohagen');
+
+            let subscribed = false;
+            let nonStartedStream = Rx.Observable.defer(() => {
+                subscribed = true;
+                return Rx.Observable.return(Unit.default);
+            });
+            registrar.registerStream(nonStartedStream, 'Barry');
+
+            let actualResult;
+            let onNextCount = 0;
+            let onCompletedCount = 0;
+
+            registrar.load()
+                .subscribe(result => {
+                        actualResult = result;
+                        onNextCount++;
+                    },
+                    e => {},
+                    () => {
+                        onCompletedCount++;
+                    });
+
+            stream.onError(new Error('Spanner in the works'));
+            expect(onCompletedCount).toEqual(1);
+            expect(onNextCount).toEqual(2);
+            expect(actualResult.stage).toEqual('error');
+            expect(actualResult.name).toEqual('Cohagen');
+            expect(subscribed).toEqual(false);
+        });
     });
     
     describe('Actions are handled tests', () => {
-        
+        it('Should treat an action like a stream', () => {
+            let called = false;
+            let action = () => {
+                called = true;
+            };
+
+            registrar.registerAction(action, 'Cohagen');
+            let actualResult;
+            let onNextCount = 0;
+            let errorCount = 0;
+            let onCompletedCount = 0;
+
+            registrar.load()
+                .subscribe(result => {
+                        actualResult = result;
+                        onNextCount++;
+                    },
+                    e => errorCount++,
+                    () => onCompletedCount++);
+
+            expect(errorCount).toEqual(0);
+            expect(onCompletedCount).toEqual(1);
+            expect(onNextCount).toEqual(2);
+            expect(actualResult.stage).toEqual('completed');
+            expect(actualResult.name).toEqual('Cohagen');
+            expect(called).toEqual(true);
+        });
+
+        it('Should treat a throw like a normal stream error', () => {
+            let called = false;
+            let action = () => {
+                called = true;
+                throw new Error('Spanner in the works');
+            };
+
+            registrar.registerAction(action, 'Cohagen');
+            let actualResult;
+            let onNextCount = 0;
+            let errorCount = 0;
+            let onCompletedCount = 0;
+
+            registrar.load()
+                .subscribe(result => {
+                        actualResult = result;
+                        onNextCount++;
+                    },
+                    e => errorCount++,
+                    () => onCompletedCount++);
+
+            expect(errorCount).toEqual(0);
+            expect(onCompletedCount).toEqual(1);
+            expect(onNextCount).toEqual(2);
+            expect(actualResult.stage).toEqual('error');
+            expect(actualResult.name).toEqual('Cohagen');
+            expect(called).toEqual(true);
+        });
     });
     
     describe('Streams tests', () => {
-        
-    })
+        it('Should yield back completed for a stream', () => {
+            let stream = new Rx.Subject();
+            registrar.registerStream(stream, 'Cohagen');
+
+            let completed = false;
+            let results: Array<LoadResult> = [];
+            registrar.load()
+                .subscribe(
+                    result => results.push(result),
+                    e => {},
+                    () => completed = true
+                );
+
+            stream.onNext(1);
+
+            expect(results.length).toEqual(2);
+            expect(results[0].stage).toEqual('starting');
+            expect(results[1].stage).toEqual('completed');
+            expect(completed).toEqual(true);
+        });
+
+        it('Should only complete after all prereqs finish successfully', () => {
+            let stream1 = new Rx.Subject();
+            let stream2 = new Rx.Subject();
+            registrar.registerStream(stream1, 'stream1');
+            registrar.registerStream(stream2, 'stream2');
+
+            let completed = false;
+            let results: Array<LoadResult> = [];
+            registrar.load()
+                .subscribe(
+                    result => results.push(result),
+                    e => {},
+                    () => completed = true
+                );
+
+            stream1.onNext(1);
+
+            expect(results.length).toEqual(3);
+            expect(results[0].stage).toEqual('starting');
+            expect(results[0].name).toEqual('stream1');
+            expect(results[1].stage).toEqual('completed');
+            expect(results[1].name).toEqual('stream1');
+            expect(results[2].stage).toEqual('starting');
+            expect(results[2].name).toEqual('stream2');
+
+            expect(completed).toEqual(false);
+
+            stream2.onNext(2);
+            expect(results.length).toEqual(4);
+            expect(results[3].stage).toEqual('completed');
+            expect(results[3].name).toEqual('stream2');
+            expect(completed).toEqual(true);
+        });
+
+        it('Should run all prereqs in the order that they were registered and subscribe once the previous has completed', () => {
+            let stream1 = new Rx.Subject();
+            let stream2 = new Rx.Subject();
+
+            let counter = 0;
+            let stream1Counter = 0;
+            let stream2Counter = 0;
+
+            registrar.registerStream(stream1.doOnSubscribe(() => stream1Counter = ++counter), 'stream1');
+            registrar.registerStream(stream2.doOnSubscribe(() => stream2Counter = ++counter), 'stream2');
+
+            registrar.load()
+                .subscribe();
+
+            expect(stream1Counter).toEqual(1);
+            expect(stream2Counter).toEqual(0);
+
+            stream1.onNext({});
+            expect(stream2Counter).toEqual(2);
+        });
+
+        it('Should handle a case where a stream does not yield and just completes', () => {
+
+        });
+    });
 });

--- a/typings/custom/rx/index.d.ts
+++ b/typings/custom/rx/index.d.ts
@@ -3,6 +3,8 @@ import { Router } from 'esp-js';
 
 declare module 'rx' {
     interface Observable<T> {
+        doOnSubscribe<T>(action: () => void) : Rx.Observable<T>;
+
         // I can't find a way of extending ConnectableObservable in TS
         lazyConnect<T>(disposable: Rx.Disposable) : Rx.Observable<T>;
 

--- a/typings/custom/rx/index.d.ts
+++ b/typings/custom/rx/index.d.ts
@@ -3,6 +3,9 @@ import { Router } from 'esp-js';
 
 declare module 'rx' {
     interface Observable<T> {
+        // I can't find a way of extending ConnectableObservable in TS
+        lazyConnect<T>(disposable: Rx.Disposable) : Rx.Observable<T>;
+
         subscribeWithRouter<T, TModel>(
             router : Router,
             modelId: string,
@@ -14,6 +17,8 @@ declare module 'rx' {
 
         // this is valid rx but not on rx.all.d.ts
         timeout<TOther>(dueTime: number, other?: Observable<TOther>, scheduler?: Rx.IScheduler): Observable<T>;
+
+        takeUntilInclusive<T>(predicate: (item: T) => boolean) : Rx.Observable<T>;
     }
 
     interface ObservableStatic {

--- a/typings/globals/jest/index.d.ts
+++ b/typings/globals/jest/index.d.ts
@@ -3,11 +3,11 @@
 declare namespace Jest {
 	interface JestStatic {
 		/**
-		 * Disables automatic mocking in the functionalModule loader.
+		 * Disables automatic mocking in the module loader.
 		 */
 		autoMockOff(): void;
 		/**
-		 * Re-enables automatic mocking in the functionalModule loader.
+		 * Re-enables automatic mocking in the module loader.
 		 */
 		autoMockOn(): void;
 		/**
@@ -28,12 +28,12 @@ declare namespace Jest {
 		 */
 		genMockFunction(): Mock;
 		/**
-		 * Given the name of a functionalModule, use the automatic mocking system to generate a mocked version of the functionalModule for you.
+		 * Given the name of a module, use the automatic mocking system to generate a mocked version of the module for you.
 		 */
 		genMockFromModule(moduleName: string): Mock;
 		/**
-		 * Indicates that the functionalModule system should always return a mocked version of the specified functionalModule from require()
-		 * (e.g. that it should never return the real functionalModule).
+		 * Indicates that the module system should always return a mocked version of the specified module from require()
+		 * (e.g. that it should never return the real module).
 		 */
 		mock(moduleName: string): Mock;
 		/**
@@ -50,11 +50,11 @@ declare namespace Jest {
 		 */
 		runOnlyPendingTimers(): void;
 		/**
-		 * Explicitly supplies the mock object that the functionalModule system should return for the specified functionalModule.
+		 * Explicitly supplies the mock object that the module system should return for the specified module.
 		 */
 		setMock(moduleName: string, moduleExports: any): void;
 		/**
-		 * Indicates that the functionalModule system should never return a mocked version of the specified functionalModule from require() (e.g. that it should always return the real functionalModule).
+		 * Indicates that the module system should never return a mocked version of the specified module from require() (e.g. that it should always return the real module).
 		 */
 		unmock(moduleName: string): void;
 		/**
@@ -127,11 +127,11 @@ declare namespace Jest {
 // Node require extensions
 interface NodeRequire {
 	/**
-	 * Returns the actual functionalModule instead of a mock, bypassing all checks on whether the functionalModule should receive a mock implementation or not.
+	 * Returns the actual module instead of a mock, bypassing all checks on whether the module should receive a mock implementation or not.
 	 */
 	requireActual(moduleName: string): any;
 	/**
-	 * Returns a mock functionalModule instead of the actual functionalModule, bypassing all checks on whether the functionalModule should be required normally or not.
+	 * Returns a mock module instead of the actual module, bypassing all checks on whether the module should be required normally or not.
 	 */
 	requireMock(moduleName: string): Jest.Mock;
 }

--- a/typings/globals/jest/index.d.ts
+++ b/typings/globals/jest/index.d.ts
@@ -3,11 +3,11 @@
 declare namespace Jest {
 	interface JestStatic {
 		/**
-		 * Disables automatic mocking in the module loader.
+		 * Disables automatic mocking in the functionalModule loader.
 		 */
 		autoMockOff(): void;
 		/**
-		 * Re-enables automatic mocking in the module loader.
+		 * Re-enables automatic mocking in the functionalModule loader.
 		 */
 		autoMockOn(): void;
 		/**
@@ -28,12 +28,12 @@ declare namespace Jest {
 		 */
 		genMockFunction(): Mock;
 		/**
-		 * Given the name of a module, use the automatic mocking system to generate a mocked version of the module for you.
+		 * Given the name of a functionalModule, use the automatic mocking system to generate a mocked version of the functionalModule for you.
 		 */
 		genMockFromModule(moduleName: string): Mock;
 		/**
-		 * Indicates that the module system should always return a mocked version of the specified module from require() 
-		 * (e.g. that it should never return the real module).
+		 * Indicates that the functionalModule system should always return a mocked version of the specified functionalModule from require()
+		 * (e.g. that it should never return the real functionalModule).
 		 */
 		mock(moduleName: string): Mock;
 		/**
@@ -50,11 +50,11 @@ declare namespace Jest {
 		 */
 		runOnlyPendingTimers(): void;
 		/**
-		 * Explicitly supplies the mock object that the module system should return for the specified module.
+		 * Explicitly supplies the mock object that the functionalModule system should return for the specified functionalModule.
 		 */
 		setMock(moduleName: string, moduleExports: any): void;
 		/**
-		 * Indicates that the module system should never return a mocked version of the specified module from require() (e.g. that it should always return the real module).
+		 * Indicates that the functionalModule system should never return a mocked version of the specified functionalModule from require() (e.g. that it should always return the real functionalModule).
 		 */
 		unmock(moduleName: string): void;
 		/**
@@ -127,11 +127,11 @@ declare namespace Jest {
 // Node require extensions
 interface NodeRequire {
 	/**
-	 * Returns the actual module instead of a mock, bypassing all checks on whether the module should receive a mock implementation or not.
+	 * Returns the actual functionalModule instead of a mock, bypassing all checks on whether the functionalModule should receive a mock implementation or not.
 	 */
 	requireActual(moduleName: string): any;
 	/**
-	 * Returns a mock module instead of the actual module, bypassing all checks on whether the module should be required normally or not.
+	 * Returns a mock functionalModule instead of the actual functionalModule, bypassing all checks on whether the functionalModule should be required normally or not.
 	 */
 	requireMock(moduleName: string): Jest.Mock;
 }


### PR DESCRIPTION
This is a WIP and out to get opinion.

We have a requirement that modules will most likely want to get async data before they are ready to load. #5 

The most likely UI to pair this with is a progress bar type screen detailing what is going on.  We want to yield when an async operation is starting so we can let the user know what we are doing, and also when it has completed and is in error.

Another requirement is that this is easy to consume.  Module developers shouldn't have to remember to yield back two values (Starting and completed) AND also have to handle errors.  This should be something the module loader does.

To solve this, Modules will be given a registrar where they can either register streams or sync actions.  The registrar is then in charge of handling the "starting", "completed" and error yields.

At the moment this is partially implemented to show intent, doesn't handle errors properly (if an error occurs, we should stop the app possibly in the first cut).